### PR TITLE
Disambiguate filesystem additions setting and dir

### DIFF
--- a/docs/Advanced Configuration.md
+++ b/docs/Advanced Configuration.md
@@ -47,7 +47,7 @@ This declares that the contents of the folder at `config/rootfs-additions` will 
 
 ## Overwriting Files in the Root File System
 
-Any files in the `rootfs_additions` will overwrite those present in the underlying system. This can be useful if you want to change the contents of included files in the underlying Nerves system. Let's say, for example, that you want to change the behaviour of `erlinit`. You can include your own `erlinit.config`:
+Any files in the `rootfs_additions` setting will overwrite those present in the underlying system. This can be useful if you want to change the contents of included files in the underlying Nerves system. Let's say, for example, that you want to change the behaviour of `erlinit`. You can include your own `erlinit.config`:
 
 ```
 # config/rootfs-additions/etc/erlinit.config


### PR DESCRIPTION
First I thought maybe all (both setting name and dir) should use either underscore or dash, but on second thought maybe it is better to highlight that the one with underscore would be the setting; in this way the reader also knows that the setting needs to be there if they start to read at the "Overwriting Files in the Root File System" section and skip the one above (like I did because I followed a link ;)).